### PR TITLE
Add other name for network device

### DIFF
--- a/files/boot.sh
+++ b/files/boot.sh
@@ -123,7 +123,7 @@ cp -n /opt/openhab/runtime/etc/logback_debug.xml $CONFIG_DIR/
 ######################
 # Decide how to launch
 
-ETH0_FOUND=`grep "eth0" /proc/net/dev`
+ETH0_FOUND=`grep "eth0\|enp0" /proc/net/dev`
 
 if [ -n "$ETH0_FOUND" ] ;
 then 


### PR DESCRIPTION
On my coreos cluster the network device is called enp0. Don't know if there is any more universal way i linux so boot.sh don't depend on the hostos network device name. Still this would fixit on coreos.
